### PR TITLE
Fix deployer construction for neuvector-prime-byos

### DIFF
--- a/k8s/neuvector-prime-byos/deployer/Dockerfile
+++ b/k8s/neuvector-prime-byos/deployer/Dockerfile
@@ -6,6 +6,7 @@ ARG CHART_NAME
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    ca-certificates \
     gettext \
     git
 
@@ -13,7 +14,7 @@ RUN apt-get update \
 COPY tools/set-up-chart .
 RUN mkdir chart
 COPY chart ./chart
-RUN bash ./set-up-chart https://github.com/SUSE-Enceladus/neuvector-helm-gks.git byos $CHART_NAME
+RUN bash -vx ./set-up-chart https://github.com/SUSE-Enceladus/neuvector-helm-gks byos $CHART_NAME
 
 RUN cd /tmp && tar -czvf /tmp/$CHART_NAME.tar.gz chart
 

--- a/k8s/neuvector-prime-byos/schema.yaml
+++ b/k8s/neuvector-prime-byos/schema.yaml
@@ -243,6 +243,17 @@ properties:
     default: neuvector
     x-google-marketplace:
       type: NAMESPACE
+  serviceAccount:
+    type: string
+    x-google-marketplace:
+      type: SERVICE_ACCOUNT
+      serviceAccount:
+        description: >
+          Manages cluster wide resources
+        roles:
+        - type:
+          rulesType: PREDEFINED
+          rulesFromRoleName: edit
 
 required:
 - name

--- a/k8s/neuvector-prime-byos/tools/set-up-chart
+++ b/k8s/neuvector-prime-byos/tools/set-up-chart
@@ -1,11 +1,9 @@
+#!/bin/bash
+set -e  # fail if any command fails
+set -u  # fail if any variable is undefined
+
 # set up chart area.
 git clone --branch ${2} ${1}
 mkdir /tmp/chart/
 cp -a neuvector-helm-gks/charts/core/. /tmp/chart/.
 cp -a chart/${3}/. /tmp/chart
-
-
-
-
-
-


### PR DESCRIPTION
Ensure that the set-up-chart script can retrieve the chart from GitHub via https by installing the ca-certificates packages.

Update the set-up-chart script to fail if any command fails or if any of the arguments is not specified.

Run the set-up-chart script from the Dockerfile with bash -vx to show details on the commands being run when a failure occurs.

Add a minimal serviceAccount entry to the schema.yaml.

<!--- /gcbrun -->
