### PR TITLE
schema updates to get product listing working

### DIFF
--- a/k8s/neuvector-prime-byos/schema.yaml
+++ b/k8s/neuvector-prime-byos/schema.yaml
@@ -46,193 +46,6 @@ x-google-marketplace:
 #   istio:
 #     type: OPTIONAL
 
-  deployerServiceAccount:
-    description: >
-      The deployer service account needs to be granted the relevant
-      privileges to be able to create the NeuVector app's resources,
-      including the CspAdapterUsageRecord CRD and it's associated
-      neuvector-usage resource.
-    type: string
-    roles:
-    - type: ClusterRole
-      rulesType: CUSTOM
-      rules:
-
-      - apiGroups: [""]
-        resources:
-        - "namespaces"
-        - "nodes"
-        - "pods"
-        - "services"
-
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-        - "update"
-
-      - apiGroups: [""]
-        resources:
-        - "bindings"
-        - "configmaps"
-        - "endpoints"
-        - "events"
-        - "limitranges"
-        - "namespaces/status"
-        - "persistentvolumeclaims"
-        - "persistentvolumeclaims/status"
-        - "pods/log"
-        - "pods/status"
-        - "replicationcontrollers"
-        - "replicationcontrollers/scale"
-        - "replicationcontrollers/status"
-        - "resourcequotas"
-        - "resourcequotas/status"
-        - "serviceaccounts"
-        - "services/status"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-      - apiGroups: ["apiextensions.k8s.io"]
-        resources:
-        - "customresourcedefinitions"
-        verbs: ['*']
-
-      - apiGroups: ["admissionregistration.k8s.io"]
-        resources:
-        - "mutatingwebhookconfigurations"
-        - "validatingwebhookconfigurations"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-        - "create"
-        - "update"
-        - "delete"
-        - "patch"
-
-      - apiGroups: ["discovery.k8s.io"]
-        resources:
-        - "endpointslices"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-      - apiGroups: ["networking.k8s.io"]
-        resources:
-        - "ingresses"
-        - "ingresses/status"
-        - "networkpolicies"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-      - apiGroups: ["rbac.authorization.k8s.io"]
-        resources:
-        - "clusterrolebindings"
-        - "clusterroles"
-        - "rolebindings"
-        - "roles"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-        - "create"
-        - "patch"
-
-      - apiGroups: ["neuvector.com"]
-        resources:
-        - "nvadmissioncontrolsecurityrules"
-        - "nvwafsecurityrules"
-        - "nvclustersecurityrules"
-        - "nvdlpsecurityrules"
-        - "nvsecurityrules"
-        verbs:
-        - "list"
-        - "delete"
-
-      - apiGroups: ["susecloud.net"]
-        resources:
-        - "cspadapterusagerecords"
-        verbs:
-        - "get"
-        - "create"
-        - "update"
-        - "delete"
-        - "patch"
-
-      - apiGroups: ["apps"]
-        resources:
-        - "controllerrevisions"
-        - "daemonsets"
-        - "daemonsets/status"
-        - "deployments"
-        - "deployments/scale"
-        - "deployments/status"
-        - "replicasets"
-        - "replicasets/scale"
-        - "replicasets/status"
-        - "statefulsets"
-        - "statefulsets/scale"
-        - "statefulsets/status"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-      - apiGroups: ["autoscaling"]
-        resources:
-        - "horizontalpodautoscalers"
-        - "horizontalpodautoscalers/status"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-      - apiGroups: ["batch"]
-        resources:
-        - "cronjobs"
-        - "cronjobs/status"
-        - "jobs"
-        - "jobs/status"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-      - apiGroups: ["extensions"]
-        resources:
-        - "daemonsets"
-        - "daemonsets/status"
-        - "deployments"
-        - "deployments/scale"
-        - "deployments/status"
-        - "ingresses"
-        - "ingresses/status"
-        - "networkpolicies"
-        - "replicasets"
-        - "replicasets/scale"
-        - "replicasets/status"
-        - "replicationcontrollers/scale"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-      - apiGroups: ["policy"]
-        resources:
-        - "poddisruptionbudgets"
-        - "poddisruptionbudgets/status"
-        verbs:
-        - "get"
-        - "list"
-        - "watch"
-
-
 properties:
   name:
     type: string
@@ -243,17 +56,381 @@ properties:
     default: neuvector
     x-google-marketplace:
       type: NAMESPACE
-  serviceAccount:
+  neuvector.serviceAccount:
     type: string
+    title: Neuvector Service Account
     x-google-marketplace:
       type: SERVICE_ACCOUNT
       serviceAccount:
         description: >
           Manages cluster wide resources
         roles:
-        - type:
-          rulesType: PREDEFINED
-          rulesFromRoleName: edit
+        - type: ClusterRole
+          rulesType: CUSTOM
+          rules:
+
+          - apiGroups: [""]
+            resources:
+            - "namespaces"
+            - "nodes"
+            - "pods"
+            - "services"
+
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "update"
+
+          - apiGroups: [""]
+            resources:
+            - "bindings"
+            - "configmaps"
+            - "endpoints"
+            - "events"
+            - "limitranges"
+            - "namespaces/status"
+            - "persistentvolumeclaims"
+            - "persistentvolumeclaims/status"
+            - "pods/log"
+            - "pods/status"
+            - "replicationcontrollers"
+            - "replicationcontrollers/scale"
+            - "replicationcontrollers/status"
+            - "resourcequotas"
+            - "resourcequotas/status"
+            - "serviceaccounts"
+            - "services/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources:
+            - "customresourcedefinitions"
+            verbs: ['*']
+
+          - apiGroups: ["admissionregistration.k8s.io"]
+            resources:
+            - "mutatingwebhookconfigurations"
+            - "validatingwebhookconfigurations"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "create"
+            - "update"
+            - "delete"
+            - "patch"
+
+          - apiGroups: ["discovery.k8s.io"]
+            resources:
+            - "endpointslices"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["networking.k8s.io"]
+            resources:
+            - "ingresses"
+            - "ingresses/status"
+            - "networkpolicies"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["rbac.authorization.k8s.io"]
+            resources:
+            - "clusterrolebindings"
+            - "clusterroles"
+            - "rolebindings"
+            - "roles"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "create"
+            - "patch"
+
+          - apiGroups: ["neuvector.com"]
+            resources:
+            - "nvadmissioncontrolsecurityrules"
+            - "nvwafsecurityrules"
+            - "nvclustersecurityrules"
+            - "nvdlpsecurityrules"
+            - "nvsecurityrules"
+            verbs:
+            - "list"
+            - "delete"
+
+          - apiGroups: ["susecloud.net"]
+            resources:
+            - "cspadapterusagerecords"
+            verbs:
+            - "get"
+            - "create"
+            - "update"
+            - "delete"
+            - "patch"
+
+          - apiGroups: ["apps"]
+            resources:
+            - "controllerrevisions"
+            - "daemonsets"
+            - "daemonsets/status"
+            - "deployments"
+            - "deployments/scale"
+            - "deployments/status"
+            - "replicasets"
+            - "replicasets/scale"
+            - "replicasets/status"
+            - "statefulsets"
+            - "statefulsets/scale"
+            - "statefulsets/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["autoscaling"]
+            resources:
+            - "horizontalpodautoscalers"
+            - "horizontalpodautoscalers/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["batch"]
+            resources:
+            - "cronjobs"
+            - "cronjobs/status"
+            - "jobs"
+            - "jobs/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["extensions"]
+            resources:
+            - "daemonsets"
+            - "daemonsets/status"
+            - "deployments"
+            - "deployments/scale"
+            - "deployments/status"
+            - "ingresses"
+            - "ingresses/status"
+            - "networkpolicies"
+            - "replicasets"
+            - "replicasets/scale"
+            - "replicasets/status"
+            - "replicationcontrollers/scale"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["policy"]
+            resources:
+            - "poddisruptionbudgets"
+            - "poddisruptionbudgets/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+  deployerServiceAccount:
+    type: string
+    title: Neuvector Service Account
+    x-google-marketplace:
+      type: SERVICE_ACCOUNT
+      serviceAccount:
+        description: >
+          The deployer service account needs to be granted the relevant
+          privileges to be able to create the NeuVector app's resources,
+          including the CspAdapterUsageRecord CRD and it's associated
+          neuvector-usage resource.
+        roles:
+        - type: ClusterRole
+          rulesType: CUSTOM
+          rules:
+
+          - apiGroups: [""]
+            resources:
+            - "namespaces"
+            - "nodes"
+            - "pods"
+            - "services"
+
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "update"
+
+          - apiGroups: [""]
+            resources:
+            - "bindings"
+            - "configmaps"
+            - "endpoints"
+            - "events"
+            - "limitranges"
+            - "namespaces/status"
+            - "persistentvolumeclaims"
+            - "persistentvolumeclaims/status"
+            - "pods/log"
+            - "pods/status"
+            - "replicationcontrollers"
+            - "replicationcontrollers/scale"
+            - "replicationcontrollers/status"
+            - "resourcequotas"
+            - "resourcequotas/status"
+            - "serviceaccounts"
+            - "services/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources:
+            - "customresourcedefinitions"
+            verbs: ['*']
+
+          - apiGroups: ["admissionregistration.k8s.io"]
+            resources:
+            - "mutatingwebhookconfigurations"
+            - "validatingwebhookconfigurations"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "create"
+            - "update"
+            - "delete"
+            - "patch"
+
+          - apiGroups: ["discovery.k8s.io"]
+            resources:
+            - "endpointslices"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["networking.k8s.io"]
+            resources:
+            - "ingresses"
+            - "ingresses/status"
+            - "networkpolicies"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["rbac.authorization.k8s.io"]
+            resources:
+            - "clusterrolebindings"
+            - "clusterroles"
+            - "rolebindings"
+            - "roles"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+            - "create"
+            - "patch"
+
+          - apiGroups: ["neuvector.com"]
+            resources:
+            - "nvadmissioncontrolsecurityrules"
+            - "nvwafsecurityrules"
+            - "nvclustersecurityrules"
+            - "nvdlpsecurityrules"
+            - "nvsecurityrules"
+            verbs:
+            - "list"
+            - "delete"
+
+          - apiGroups: ["susecloud.net"]
+            resources:
+            - "cspadapterusagerecords"
+            verbs:
+            - "get"
+            - "create"
+            - "update"
+            - "delete"
+            - "patch"
+
+          - apiGroups: ["apps"]
+            resources:
+            - "controllerrevisions"
+            - "daemonsets"
+            - "daemonsets/status"
+            - "deployments"
+            - "deployments/scale"
+            - "deployments/status"
+            - "replicasets"
+            - "replicasets/scale"
+            - "replicasets/status"
+            - "statefulsets"
+            - "statefulsets/scale"
+            - "statefulsets/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["autoscaling"]
+            resources:
+            - "horizontalpodautoscalers"
+            - "horizontalpodautoscalers/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["batch"]
+            resources:
+            - "cronjobs"
+            - "cronjobs/status"
+            - "jobs"
+            - "jobs/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["extensions"]
+            resources:
+            - "daemonsets"
+            - "daemonsets/status"
+            - "deployments"
+            - "deployments/scale"
+            - "deployments/status"
+            - "ingresses"
+            - "ingresses/status"
+            - "networkpolicies"
+            - "replicasets"
+            - "replicasets/scale"
+            - "replicasets/status"
+            - "replicationcontrollers/scale"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
+
+          - apiGroups: ["policy"]
+            resources:
+            - "poddisruptionbudgets"
+            - "poddisruptionbudgets/status"
+            verbs:
+            - "get"
+            - "list"
+            - "watch"
 
 required:
 - name


### PR DESCRIPTION
We needed updated to the service accounts specs in the scheme so the google tools could do their checks.

Needed to move deployer service account into properties section and be explicit on neuvector service account privs,
Privs are pretty broad and we should look at trimming these back later.

<!--- /gcbrun -->
